### PR TITLE
cmd+backspace for deletion on mac

### DIFF
--- a/src/application/gactions.rs
+++ b/src/application/gactions.rs
@@ -126,7 +126,7 @@ lazy_static! {
         GAction::new("new", &["<primary>N"], None, None, Application::gaction_new),
         GAction::new(
             "delete-block",
-            &["Delete"],
+            &["Delete", "<primary>BackSpace"],
             None,
             None,
             Application::gaction_delete_block


### PR DESCRIPTION
This is the shortcut used everywhere to delete anything on mac