### PR TITLE
Update .gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,4 @@
 /target
-Cargo.lock
 .vscode/
 vendor/
 gtk4-rs/


### PR DESCRIPTION
Removed Cargo.lock from .gitignore
Without this PR #45 is not very helpful.